### PR TITLE
agents: parse broken JSON

### DIFF
--- a/langchain/src/agents/chat_convo/outputParser.ts
+++ b/langchain/src/agents/chat_convo/outputParser.ts
@@ -62,10 +62,27 @@ export class ChatConversationalAgentOutputParser extends AgentActionOutputParser
         return { returnValues: { output: action_input }, log: text };
       }
       return { tool: action, toolInput: action_input, log: text };
+    }
+    catch (e) {
+      const response = this.parseBrokenJson(jsonOutput)
+      const { action, action_input } = response
+      if (action === "Final Answer") {
+        return { returnValues: { output: action_input }, log: text }
+      }
+      return { tool: action, toolInput: action_input, log: text }
+    }
+  }
+
+  parseBrokenJson (text: string) {
+    try {
+      const regex = /"action": "([^"]+)",\s+"action_input": "([^"]+)"/g
+      const [matches] = [...text.matchAll(regex)]
+
+      return { action: matches[1], action_input: matches[2] }
     } catch (e) {
       throw new OutputParserException(
         `Failed to parse. Text: "${text}". Error: ${e}`
-      );
+      )
     }
   }
 


### PR DESCRIPTION
This commit adds a parseBrokenJson method to the ChatConversationalAgentOutputParser class, which is used to parse broken JSON output from the agent. The method uses a regular expression to extract the action and action_input properties from the JSON string, and returns them as an object.

The parseOutput method has been modified to catch JSON parsing errors and call the parseBrokenJson method to extract the properties from the broken JSON. If the action property is "Final Answer", the method returns the action_input property as the output value.

Code changes can be found in langchain/src/agents/chat_convo/outputParser.ts.